### PR TITLE
Renaming `blocks` variable to `restful_blocks`

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ It does this by extracting the metadata from all Gutenberg blocks inside of a bl
 The plugin makes the following REST API field available on objects of `post` type:
 
 ```javascript
-blocks: [...]
+restful_blocks: [...]
 ```
 
 ## How does it work?

--- a/readme.txt
+++ b/readme.txt
@@ -17,7 +17,7 @@ It does this by extracting the metadata from all Gutenberg blocks inside of a bl
 
 The plugin makes the following REST API field available on objects of `post` type:
 
-`blocks: [...]`
+`restful_blocks: [...]`
 
 Demonstration:
 

--- a/src/RESTHooks.php
+++ b/src/RESTHooks.php
@@ -22,7 +22,7 @@ class RESTHooks {
             
             $allowed_objects = \apply_filters( 'Zamaneh\RestfulBlocks\RESTHooks::objectType', array( 'post', 'page' ) );
                         
-            \register_rest_field( $allowed_objects, 'blocks', array(
+            \register_rest_field( $allowed_objects, 'restful_blocks', array(
                 'get_callback'      => [RESTHooks::class, 'get_blocks'],
                 'update_callback'   => null,
                 'schema'            => array(


### PR DESCRIPTION
Somewhere around the Wordpress 5.9 update the WP core is reserving blocks as a variable. This PR renames the plugin variable to restful_blocks to avoid conflict.